### PR TITLE
Update subscriber.rst

### DIFF
--- a/docs/subscriber.rst
+++ b/docs/subscriber.rst
@@ -215,7 +215,7 @@ view to listen for notifications:
         def handle_subscription(self):
             payload = self.request.body
             parsed = feedparser.parse(payload)
-            for entry in payload.entries:
+            for entry in parsed.entries:
                 do_stuff_with(entry)
     callback = MyCallback.as_view()
 


### PR DESCRIPTION
Fixes #27


for entry in payload.entries: 

should be
for entry in parsed.entries:

[Rendered markdown](https://django-push.readthedocs.io/en/latest/subscriber.html#listening-with-a-view-instead-of-the-updated-signal) 
